### PR TITLE
Update the peer dependencies for allowing angular 5.0.0 versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "release": "standard-version"
   },
   "peerDependencies": {
-    "@angular/core": ">=4.0.0 <5.0.0",
-    "@angular/common": ">=4.0.0 <5.0.0"
+    "@angular/core": ">=4.0.0 <6.0.0",
+    "@angular/common": ">=4.0.0 <6.0.0"
   },
   "devDependencies": {
     "@angular/common": "~4.1.3",


### PR DESCRIPTION
Requesting we allow angular version 5 peer dependencies.  I was seeing the following:

`+-- UNMET PEER DEPENDENCY @angular/common@5.2.4`
`+-- UNMET PEER DEPENDENCY @angular/core@5.2.4`